### PR TITLE
TravisBuddy Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: node_js
 node_js:
-  - "8"
+  - '8'
 script:
-  - npm test
-  - npm run lint
+  - 'npm test'
+  - 'npm run lint'
+notifications:
+  webhooks:
+    urls:
+      - 'https://www.travisbuddy.com/'
+    on_success: never
+    on_failure: always
+    on_start: never
+    on_cancel: never
+    on_error: never


### PR DESCRIPTION
TravisBuddy will comment on pull requests in your public repository everytime a test failed in one of them. The comment will include only the part of the build log that applies to your testing framework, so your contirbutors won't have to enter Travis's website and search the long and annoying build log for the reason the tests failed.
  
  Here's an example: https://github.com/bluzi/static-server/pull/1