### PR TITLE
fix english error in default success message

### DIFF
--- a/resources/messages/success/default.success.template.md
+++ b/resources/messages/success/default.success.template.md
@@ -1,2 +1,2 @@
 Hey @{{pullRequestAuthor}},  
-Your changes looks good to me!
+Your changes look good to me!


### PR DESCRIPTION
When testing the #89 I noticed that there is an English grammar error in the default success message. Here's the (very) small fix :)