### PR TITLE
Add 'global' option to Regex to parse Travis job logs

### DIFF
--- a/pipes/fetch-job-scripts.pipe.js
+++ b/pipes/fetch-job-scripts.pipe.js
@@ -91,7 +91,7 @@ const getJobScripts = async (context, job) => {
       scriptContentsAfterCut = scriptContents;
 
       if (context.config.regex) {
-        const regex = new RegExp(context.config.regex);
+        const regex = new RegExp(context.config.regex, 'g');
         const regexResult = regex.exec(scriptContents);
         if (regexResult && regexResult.length > 1) {
           [, scriptContents] = regexResult;

--- a/pipes/fetch-job-scripts.pipe.js
+++ b/pipes/fetch-job-scripts.pipe.js
@@ -91,10 +91,11 @@ const getJobScripts = async (context, job) => {
       scriptContentsAfterCut = scriptContents;
 
       if (context.config.regex) {
-        const regex = new RegExp(context.config.regex, 'g');
+        const regex = new RegExp(context.config.regex, context.config.regexOptions);
         const regexResult = regex.exec(scriptContents);
+        // Retrieve the full strings of chars matched.
         if (regexResult && regexResult.length > 1) {
-          [, scriptContents] = regexResult;
+          scriptContents = regexResult[0];
         } else {
           scriptContents = undefined;
         }


### PR DESCRIPTION
Adding global option helps to match all the occurence of the
specified pattern instead of stopping at the first instance

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>